### PR TITLE
Fix: Add Sprockets to gems to fix 'could not load sprockets/railtie' error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,5 +53,6 @@ end
 
 group :development do
   gem 'graphiql-rails'
+  gem 'sprockets'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (~> 5.0)
   simplecov
+  sprockets
   tzinfo-data
 
 RUBY VERSION

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 # require "rails/test_unit/railtie"
+require 'sprockets/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 # require "rails/test_unit/railtie"
-require 'sprockets/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
## Description
- Fix: Add Sprockets to gems to fix 'could not load sprockets/railtie' error deploying to heroku
