### PR TITLE
Fix: Remove sprockets and 'sprockets/railtie'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ gem "bootsnap", require: false
 # GraphQL is a query language for APIs and a runtime for fulfilling those queries with the existing data. 
 gem 'graphql'
 gem 'faraday'
-gem 'sprockets'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,6 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (~> 5.0)
   simplecov
-  sprockets
   tzinfo-data
 
 RUBY VERSION

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,8 +12,7 @@ require "action_mailbox/engine"
 require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-# require "rails/test_unit/railtie"
-require 'sprockets/railtie'
+#require 'sprockets/railtie'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
## Description
- Fix: Remove sprockets and 'sprockets/railtie' as the previous fixes to add the sprockets gem still resulted in issues deploying to Heroku

