### PR TITLE
Chore: Add production database variable to enable Heroku PostgreSQL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -83,4 +83,5 @@ production:
   <<: *default
   database: BE_foodie_brain_production
   username: BE_foodie_brain
+  url: <%= ENV['DATABASE_URL'] %>
   password: <%= ENV["BE_FOODIE_BRAIN_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
### Description of changes
- Adds `url: <%= ENV['DATABASE_URL'] %>` to the production database.yml in order to enable the Heroku PostgreSQL database

#### Add GIF (REQUIRED)
![giphy (1)](https://github.com/Foodie-Brain/be_foodie/assets/117330008/3ca58a1e-7672-4388-9352-9a93919277c8)
