### PR TITLE
11 create review endpoint test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore SimpleCov files
+/coverage

--- a/app/graphql/mutations/create_review.rb
+++ b/app/graphql/mutations/create_review.rb
@@ -2,15 +2,15 @@ class Mutations::CreateReview < Mutations::BaseMutation
   argument :name, String, required: true
   argument :photo, String #TODO: Make field required
   argument :description, String, required: true
-  argument :dairy_free, Integer
-  argument :gluten_free, Integer
-  argument :halal, Integer
-  argument :kosher, Integer
-  argument :nut_free, Integer
-  argument :vegan, Integer
-  argument :vegitarian, Integer
-  argument :likes, Integer
-  argument :dislikes, Integer
+  argument :dairy_free, Integer, required: false, default_value: 0
+  argument :gluten_free, Integer, required: false, default_value: 0
+  argument :halal, Integer, required: false, default_value: 0
+  argument :kosher, Integer, required: false, default_value: 0
+  argument :nut_free, Integer, required: false, default_value: 0
+  argument :vegan, Integer, required: false, default_value: 0
+  argument :vegitarian, Integer, required: false, default_value: 0
+  argument :likes, Integer, required: false, default_value: 0
+  argument :dislikes, Integer, required: false, default_value: 0
   argument :lat, String, required: true
   argument :lon, String, required: true
 

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -1,18 +1,18 @@
 FactoryBot.define do
   factory :review do
-    name { "MyString" }
-    photo { "MyString" }
-    description { "MyString" }
-    dairy_free { 1 }
-    gluten_free { 1 }
-    halal { 1 }
-    kosher { 1 }
-    nut_free { 1 }
-    vegan { 1 }
-    vegitarian { 1 }
-    likes { 1 }
-    dislikes { 1 }
-    lat { "MyString" }
-    lon { "MyString" }
+    name { Faker::Food.dish }
+    photo { "#{Faker::JapaneseMedia::StudioGhibli.character}.jpg" }
+    description { Faker::Food.description }
+    dairy_free { Faker::Number.between(from: 0, to: 1) }
+    gluten_free { Faker::Number.between(from: 0, to: 1) }
+    halal { Faker::Number.between(from: 0, to: 1) }
+    kosher { Faker::Number.between(from: 0, to: 1) }
+    nut_free { Faker::Number.between(from: 0, to: 1) }
+    vegan { Faker::Number.between(from: 0, to: 1) }
+    vegitarian { Faker::Number.between(from: 0, to: 1) }
+    likes { Faker::Number.between(from: 0, to: 1000) }
+    dislikes { Faker::Number.between(from: 0, to: 1000) }
+    lat { Faker::Address.latitude }
+    lon { Faker::Address.longitude }
   end
 end

--- a/spec/graphql/mutations/create_review_spec.rb
+++ b/spec/graphql/mutations/create_review_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateReview, type: :mutation do
+  describe 'createReview' do
+    let(:name) { "Cinnamon Coffee Cake" }
+    let(:description) { "Found this absolutely delicious coffee cake at Kochi coffee, and it's gluten-free!" }
+    let(:photo) { "fake_url.png" }
+    let(:gluten_free) { 1 }
+    let(:lat) { "39.72740886344144" }
+    let(:lon) { "-104.93939410569635" }
+
+    # Create a valid GraphQL query for the mutation
+      let(:mutation) do
+        <<~GQL
+          mutation createReview($input: CreateReviewInput!) {
+            createReview(input: $input) {
+              id
+              name
+              description
+              photo
+              dairyFree
+              glutenFree
+              halal
+              kosher
+              nutFree
+              vegan
+              vegitarian
+              likes
+              dislikes
+              lat
+              lon
+            }
+          }
+        GQL
+      end
+
+    it 'creates a new review' do
+      input = {
+        name: name,
+        description: description,
+        photo: photo,
+        glutenFree: gluten_free,
+        lat: lat,
+        lon: lon
+      }
+
+      result = BeFoodieBrainSchema.execute(
+        mutation,
+        variables: { input: input }
+      )
+
+      expect(result["errors"]).to be_nil
+
+      review = Review.last
+
+      # Expected defined attributes from request
+      expect(result.dig("data", "createReview", "id")).to eq(review.id.to_s)
+      expect(result.dig("data", "createReview", "name")).to eq(name)
+      expect(result.dig("data", "createReview", "description")).to eq(description)
+      expect(result.dig("data", "createReview", "photo")).to eq(photo)
+      expect(result.dig("data", "createReview", "glutenFree")).to eq(gluten_free)
+      expect(result.dig("data", "createReview", "lat")).to eq(lat)
+      expect(result.dig("data", "createReview", "lon")).to eq(lon)
+
+      #expected default values not defined in request
+      expect(result.dig("data", "createReview", "dairyFree")).to eq(0)
+      expect(result.dig("data", "createReview", "halal")).to eq(0)
+      expect(result.dig("data", "createReview", "kosher")).to eq(0)
+      expect(result.dig("data", "createReview", "nutFree")).to eq(0)
+      expect(result.dig("data", "createReview", "vegan")).to eq(0)
+      expect(result.dig("data", "createReview", "vegitarian")).to eq(0)
+      expect(result.dig("data", "createReview", "likes")).to eq(0)
+      expect(result.dig("data", "createReview", "dislikes")).to eq(0)
+    end
+  end
+end

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Types::QueryType, type: :query do
+  describe "Reviews" do
+    
+  end
+end

--- a/spec/requests/starting/tests_spec.rb
+++ b/spec/requests/starting/tests_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "first tests case"  do
-  it 'can check numbers' do 
-
-  end
-end


### PR DESCRIPTION
### Description of changes
- Updates the Review factory with faker data
- Removes previous request spec skeleton
- Adds Graphql Types test skeleton
- Updates the Graphql CreateReview object parameters to specify some values are not required and have a default value of 0.
- Adds test for the create a review call using graphql

### Endpoint example request:
```
post '.../graphql'

body:
  mutation {
        createReview(input: {
          name: "FireCracker Sushi", 
          photo: "nada.jpg", 
          description: "Fried sushi roll with salmon, creamcheese, and jalapenos",
          dairyFree: 1, 
          glutenFree: 1, 
          halal: 1, 
          kosher: 1, 
          nutFree: 1, 
          vegan: 1, 
          vegitarian: 1, 
          likes: 312, 
          dislikes: 5, 
          lat: "39.72903251256764", 
          lon: "-104.93865153415369"
        }) {
        	  id
            name
            description
            glutenFree
            lat
        	  lon
        }

```

### Test Suite
- [x] Are all tests within the test suite passing?
- _Tests are passing with 95.4% coverage -- the missing coverage can be solved by completing the tests for the type methods and testing the graphql review schema_

### Specific Feedback Request(s)

#### Add GIF (REQUIRED)
![giphy (2)](https://github.com/Foodie-Brain/be_foodie/assets/117330008/b6495918-95b7-482a-b5c2-59e16c699bac)
