### PR TITLE
test: add sad path testing for creating review

### DIFF
--- a/app/graphql/mutations/create_review.rb
+++ b/app/graphql/mutations/create_review.rb
@@ -15,9 +15,10 @@ class Mutations::CreateReview < Mutations::BaseMutation
   argument :lon, String, required: true
 
   type Types::ReviewType
+  field :errors, [String], null: false
 
   def resolve(name:, photo:, description:, dairy_free:, gluten_free:, halal:, kosher:, nut_free:, vegan:, vegetarian:, likes:, dislikes:, lat:, lon:)
-    Review.create(name: name, 
+    review = Review.new(name: name, 
       photo: photo, 
       description: description, 
       dairy_free: dairy_free, 
@@ -31,5 +32,12 @@ class Mutations::CreateReview < Mutations::BaseMutation
       dislikes: dislikes, 
       lat: lat, 
       lon: lon)
+
+      if review.valid?
+        review.save
+      else
+        raise GraphQL::ExecutionError, review.errors.full_messages.join(', ')
+      end
+      review
   end
 end

--- a/spec/graphql/mutations/create_review_spec.rb
+++ b/spec/graphql/mutations/create_review_spec.rb
@@ -73,4 +73,73 @@ RSpec.describe Mutations::CreateReview, type: :mutation do
       expect(result.dig("data", "createReview", "dislikes")).to eq(0)
     end
   end
+
+  describe 'returns an error when no input is provided' do
+    let(:name) { "Cinnamon Coffee Cake" }
+    let(:description) { "Found this absolutely delicious coffee cake at Kochi coffee, and it's gluten-free!" }
+    let(:photo) { "fake_url.png" }
+    let(:gluten_free) { 1 }
+    let(:lat) { "39.72740886344144" }
+    let(:lon) { "-104.93939410569635" }
+
+      let(:mutation) do
+        <<~GQL
+          mutation createReview($input: CreateReviewInput!) {
+            createReview(input: $input) {
+              id
+              name
+              description
+              photo
+              dairyFree
+              glutenFree
+              halal
+              kosher
+              nutFree
+              vegan
+              vegetarian
+              likes
+              dislikes
+              lat
+              lon
+            }
+          }
+        GQL
+      end
+
+    it 'sad path' do
+      input = {
+        name:'',
+        description: description,
+        photo: photo,
+        glutenFree: gluten_free,
+        lat: lat,
+        lon: lon
+      }
+
+      result = BeFoodieBrainSchema.execute(
+        mutation,
+        variables: { input: input }
+      )
+
+      expect(result["errors"]).to_not be_nil
+      expect(result.dig("data", "createReview")).to be_nil
+      expect(result["errors"][0]["message"]).to eq("Name can't be blank")
+
+      input2 = {
+        name: '',
+        description: '',
+        photo: photo,
+        glutenFree: gluten_free,
+        lat: lat,
+        lon: lon
+      }
+
+      result2 = BeFoodieBrainSchema.execute(
+        mutation,
+        variables: { input: input2 }
+      )
+
+      expect(result2["errors"][0]["message"]).to eq("Name can't be blank, Description can't be blank")
+    end
+  end
 end

--- a/spec/graphql/mutations/create_review_spec.rb
+++ b/spec/graphql/mutations/create_review_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Mutations::CreateReview, type: :mutation do
         GQL
       end
 
-    it 'sad path' do
+    it 'returns an error when required fields not provided' do
       input = {
         name:'',
         description: description,


### PR DESCRIPTION
### Description of changes
This pr implements sad path testing for creating a review. 
Successfully executes via localhost.

In order to create custom error handling the resolver method in create_review.rb needed updating. 
Main changes include: Changing .create to .new and adding a conditional that executes a .save/error handling. 

### Test Suite
- [✅ ] Are all tests within the test suite passing?

### Specific Feedback Request(s)

### If you used graphiql on this branch, did you remember to comment #require 'sprockets/railtie' in the config/application.rb?
-[✅ ]


#### Add GIF (REQUIRED)

https://media.giphy.com/media/d1FL4zXfIQZMWFQQ/giphy.gif
