### PR TITLE
test: implements sad path for query review by id

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -13,7 +13,7 @@ module Types
     field :nodes, [Types::NodeType, null: true], null: true, description: "Fetches a list of objects given a list of IDs." do
       argument :ids, [ID], required: true, description: "IDs of the objects."
     end
-
+    
     def nodes(ids:)
       ids.map { |id| context.schema.object_from_id(id, context) }
     end
@@ -27,9 +27,14 @@ module Types
         argument :id, ID, required: true
       end
     def review(id:)
-      Review.find_by(id: id)
-    end
+      review = Review.find_by(id: id)
 
+      if review.nil?
+        raise GraphQL::ExecutionError, "Review not found with id: #{id}"
+      end
+        review
+    end
+    
     field :reviews,
       [Types::ReviewType],
       null: false,

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -100,5 +100,38 @@ RSpec.describe Types::QueryType, type: :query do
         }
       )
     end
+
+    it 'returns an error if the review does not exist' do
+      get_review_query = <<~GQL
+      query ($review_id: ID!) {
+        review(id: $review_id) {
+          id
+          name
+          description
+          photo
+          dairyFree
+          glutenFree
+          halal
+          kosher
+          nutFree
+          vegan
+          vegetarian
+          likes
+          dislikes
+          lat
+          lon
+        }
+      }
+    GQL
+
+
+      review = create(:review) 
+      review_id = review.id
+      result = BeFoodieBrainSchema.execute(get_review_query, variables: { review_id: 555 })
+
+      expect(result["errors"]).to_not be_nil
+      expect(result.dig("data", "review")).to be_nil
+      expect(result["errors"][0]["message"]).to eq("Review not found with id: 555")
+    end
   end
 end


### PR DESCRIPTION
### Description of changes
This PR implements sad path testing for querying for a review by id with an invalid id. 
![Screenshot 2023-10-17 at 12 45 56 PM](https://github.com/Foodie-Brain/be_foodie/assets/127896538/b874360b-9411-42a6-8c6e-e36990330ca9)

The main changes include updating the review method within the file query_type.rb
Checking if the review was nil and adding a custom error stating that id does not match any reviews in the database, then returning the review if it was indeed valid. 

### Test Suite
- [✅ ] Are all tests within the test suite passing?

### Specific Feedback Request(s)


### If you used graphiql on this branch, did you remember to comment #require 'sprockets/railtie' in the config/application.rb?
-[✅ ]


#### Add GIF (REQUIRED)
![giphy](https://github.com/Foodie-Brain/be_foodie/assets/127896538/1fea1eb6-2b1e-422b-9287-ab61d7c19a88)
