### PR TITLE
Error handling destroy review

### DIFF
--- a/app/graphql/mutations/destroy_review.rb
+++ b/app/graphql/mutations/destroy_review.rb
@@ -4,6 +4,12 @@ class Mutations::DestroyReview < Mutations::BaseMutation
   type Types::ReviewType
 
   def resolve(id:)
-    Review.find(id).destroy
+    review = Review.find_by(id: id)
+
+    if review.nil? || review.blank?
+      raise GraphQL::ExecutionError, "Review not found with id: #{id}"
+    else
+      review.destroy
+    end
   end
 end

--- a/spec/graphql/mutations/destroy_review_spec.rb
+++ b/spec/graphql/mutations/destroy_review_spec.rb
@@ -33,4 +33,18 @@ RSpec.describe Mutations::DestroyReview, type: :mutation do
 
     expect(Review.all.count).to eq(0)
   end
+
+  it 'returns an error if review does not exist' do
+    input = {
+      id: 999
+    }
+
+    result = BeFoodieBrainSchema.execute(
+      mutation,
+      variables: { input: input }
+    )
+    expect(result["errors"]).to_not be_nil
+    expect(result.dig("data", "destroyReview")).to be_nil
+    expect(result.dig("errors", 0, "message")).to eq("Review not found with id: 999")
+  end
 end


### PR DESCRIPTION
### Description of changes
This pr builds onto the apps destroy functionality. 
This pr also changes the resolve method for DestroyReview a bit. 

The conditional will first check if an id is input correctly and valid, if not an error is returned. If id is valid then the review is then destroyed.
![Screenshot 2023-10-17 at 8 23 34 PM](https://github.com/Foodie-Brain/be_foodie/assets/127896538/b28bffad-b4b4-43b9-b2a7-4a9fbcbbab98)


### Test Suite
- [✅ ] Are all tests within the test suite passing?

### Specific Feedback Request(s)


### If you used graphiql on this branch, did you remember to comment #require 'sprockets/railtie' in the config/application.rb?
-[✅ ]


#### Add GIF (REQUIRED)
![giphy (1)](https://github.com/Foodie-Brain/be_foodie/assets/127896538/4f280135-a80a-4a9a-a325-f3276b087653)
